### PR TITLE
Mission 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+database.sqlite

--- a/app/models/Loss.php
+++ b/app/models/Loss.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Loss extends Model
 {
-    protected $fillable = ['lost_at', 'postal_code', 'country_id', 'pet_owner_id', 'pet_id'];
+    protected $fillable = ['lost_at', 'postal_code', 'country_id', 'pet_owner_id', 'pet_id', 'user_id'];
 
     public function pet_owner(): BelongsTo
     {


### PR DESCRIPTION
Pour cette première mission, l'explication du bug est que nous créons des *losses* dans le seeder via du _mass assignment_. Quand on fait du _mass assignment_, il est nécessaire pour des raisons de sécurité de gérer une liste des champs qui sont changeables dans la DB via les propriétés des modèles `fillable` (liste blanche) ou `guarded` (liste noire). 

Il suffit donc d’ajouter `user_id` à la propriété `fillable` déjà présente.

https://laravel.com/docs/12.x/eloquent#mass-assignment